### PR TITLE
Update Tutorial 13

### DIFF
--- a/examples/13_cmake_compilation/config/config.json
+++ b/examples/13_cmake_compilation/config/config.json
@@ -1,6 +1,6 @@
 {
     "autograding" : {
-        "submission_to_compilation" : ["CMakeLists.txt"]
+        "submission_to_compilation" : ["CMakeLists.txt", "*.cpp", "*.h"]
     },
     "max_submission_size" : 1000000,
     "testcases" : [


### PR DESCRIPTION
Fixes a misspecification which caused ```.cpp``` and ```.h``` files not to be copied to the runner in tutorial 13 (cmake compilation).