### PR TITLE
Use the publish_actions option in tutorial examples 15 and 16

### DIFF
--- a/examples/15_GLFW/config/config.json
+++ b/examples/15_GLFW/config/config.json
@@ -1,5 +1,7 @@
 {
     "max_submission_size" : 1000000,
+    // By default, show students a list of the actions taken for each testcase.
+    "publish_actions" : true,
     "testcases" : [
 
         // *************** COMPILATION *****************
@@ -178,6 +180,8 @@
         {
             "title" : "Graphics program 1",
             "command" : "./a.out -input sierpinski_triangle.txt -size 400 -iters 0 -cubes",
+            // For this testcase, do not show students a list of actions
+            "publish_actions" : false,
             "actions" : [
                             {
                                 "action" : "click and drag delta",

--- a/examples/16_docker_network_python/config/config.json
+++ b/examples/16_docker_network_python/config/config.json
@@ -2,6 +2,8 @@
     // autograding_method must be docker in order for networking to work. If you forget it,
     // your assignment should fail to build.
     "autograding_method" : "docker",
+    // By default, show students a list of the dispatcher actions taken for each testcase.
+    "publish_actions" : true,
     "container_options" : {
       //States that a given testcase uses a router by default. (Default value is true)
       "use_router" : true
@@ -18,6 +20,8 @@
     // Each testcase creates a new, unique set of docker containers and networks.
     "testcases" : [
         {
+            // For this testcase, do not show students a list of dispatcher actions
+            "publish_actions" : false,
             //Despite the default being true, this testcase will not use a router.
             "use_router" : false,
             "title" : "Simple Testcase, No Router",


### PR DESCRIPTION
The issue Submitty/Submitty#5413 introduces new syntax which allows an instructor to publish a list of dispatcher or graphics actions to their students. This PR updates tutorials 15 and 16 to make use of this new option.