### PR TITLE
Update output archival for tutorials 16-18

### DIFF
--- a/examples/16_docker_network_python/config/config.json
+++ b/examples/16_docker_network_python/config/config.json
@@ -6,10 +6,6 @@
       //States that a given testcase uses a router by default. (Default value is true)
       "use_router" : true
     },
-
-    "autograding" : {
-        "work_to_details" : [ "**/*.txt" ]
-    },
     "resource_limits" : {
         "RLIMIT_NPROC" : 100,
         "RLIMIT_STACK" : 10000000,

--- a/examples/17_dispatched_actions_and_standard_input/config/config.json
+++ b/examples/17_dispatched_actions_and_standard_input/config/config.json
@@ -1,8 +1,4 @@
 {
-
-  "autograding" : {
-    "work_to_details" : ["**/*.txt"]
-  },
   "autograding_method" : "docker",
   "container_options" : {
       //States that a given testcase uses a router by default. (Default value is true)

--- a/examples/18_postgres_database/config/config.json
+++ b/examples/18_postgres_database/config/config.json
@@ -7,8 +7,7 @@
     "use_router": false
   },
   "autograding": {
-    "submission_to_runner": ["**/*.py", "**/*.txt","**/*.sql"],
-    "work_to_details": ["**/*.txt"]
+    "submission_to_runner": ["**/*.py", "**/*.txt","**/*.sql"]
   },
   "testcases": [
     {


### PR DESCRIPTION
Tutorial examples 16-18 were explicitly archiving `**/*.txt` via `work_to_details`. This is no longer necessary after last summer's move to `SecureExecutionEnvironments`.