### PR TITLE
[Bugfix:Autograding] sql_runner w/ failed queries

### DIFF
--- a/examples/18_postgres_database/config/test_input/sql_runner.py
+++ b/examples/18_postgres_database/config/test_input/sql_runner.py
@@ -84,8 +84,8 @@ def main():
 
             query = load_query(input_file)
             result = run_query(curr, query)
-            conn.commit()
             cost, time = run_cost(curr, query)
+            conn.commit()
             log_query_metrics(f"Query {num:d} run in {time:.3f} sec with cost {cost:.2f}")
 
             with open(output_file, 'w', newline='', encoding='utf-8') as result_file:

--- a/examples/18_postgres_database/config/test_input/sql_runner.py
+++ b/examples/18_postgres_database/config/test_input/sql_runner.py
@@ -84,15 +84,17 @@ def main():
 
             query = load_query(input_file)
             result = run_query(curr, query)
+            conn.commit()
             cost, time = run_cost(curr, query)
-            log_query_metrics(f"Query {num:d} run in {time:.3f} sec with cost {cost:.2f}")            
-            
+            log_query_metrics(f"Query {num:d} run in {time:.3f} sec with cost {cost:.2f}")
+
             with open(output_file, 'w', newline='', encoding='utf-8') as result_file:
                 writer = csv.writer(result_file, lineterminator='\n')
                 writer.writerow([attr for attr in result[0].keys()])
                 for t in result:
                     writer.writerow(t)
         except:
+            conn.rollback()
             err("Solution for %d raised exception %s" % (num, sys.exc_info()))
 
 


### PR DESCRIPTION
The `sql_runner` failed to commit or rollback a transaction after it finished. As a result, if one query failed, all subsequent queries did, as well. 