### PR TITLE
[Bugfix:Autograding] Change python to python3

### DIFF
--- a/examples/01_simple_python/config/config.json
+++ b/examples/01_simple_python/config/config.json
@@ -7,7 +7,7 @@
       // Commands to run (in order). These are not shell commands, although 
       // they support some common shell wildcards. This can either be a 
       // list or a single string.
-      "command" : [ "python *.py" ],
+      "command" : [ "python3 *.py" ],
 
       // Point value of this testcase.
       "points" : 10, 


### PR DESCRIPTION
Not technically a current bug but will be once Submitty is upgraded to Ubuntu 22. Ubuntu 22 no longer has a default `/usr/bin/python` so python3 or python2 (if installed) must be used instead.