### PR TITLE
[Feature:Developer] Auto add PRs in this repo to project

### DIFF
--- a/.github/workflows/add_to_project.yml
+++ b/.github/workflows/add_to_project.yml
@@ -1,0 +1,25 @@
+name: "Add PR to project board"
+on:
+  pull_request_target:
+    types:
+      - opened
+
+env:
+  PR_URL: ${{ github.event.pull_request.html_url }}
+
+jobs:
+  title-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate token
+        id: generate-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.APP_PEM }}
+
+      - name: Add PR to project
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+        run: |
+          gh project item-add --owner Submitty 1 --url "$PR_URL"


### PR DESCRIPTION
Due to limitations of the Github Project feature, PRs in this repo are not currently automatically added to the project board. This PR adds a Github Action that auto-adds new PRs in this repo to the project board.