### PR TITLE
[Bugfix:Autograding] revise docker images

### DIFF
--- a/examples/02_simple_cpp/config/config.json
+++ b/examples/02_simple_cpp/config/config.json
@@ -1,7 +1,7 @@
 {
   "autograding_method": "docker",
   "container_options": {
-      "container_image": "submittyrpi/csci1200:default"
+      "container_image": "submitty/clang:latest"
   },
 
   // For compiled languages, typically two testcases are used to allow points

--- a/examples/05_cpp_static_analysis/config/config.json
+++ b/examples/05_cpp_static_analysis/config/config.json
@@ -6,7 +6,7 @@
 
     "autograding_method": "docker",
     "container_options": {
-        "container_image": "submittyrpi/csci1200:default"
+        "container_image": "submitty/autograding:latest"
     },
 
     // Static analysis can also be performed upon C++ code.
@@ -16,8 +16,8 @@
         {
             
             "title" : "Check for goto and auto",
-            "command" : [ "submitty_count token -l c Goto *.cpp",
-                          "submitty_count token -l c Auto *.cpp" ],
+            "command" : [ "submitty_count_ts -l cpp node auto *.cpp",
+                          "submitty_count_ts -l cpp node auto *.cpp" ],
             "points" : 2,
             "validation" : [
                 {

--- a/examples/08_memory_debugging/config/config.json
+++ b/examples/08_memory_debugging/config/config.json
@@ -1,7 +1,7 @@
 {
     "autograding_method": "docker",
     "container_options": {
-        "container_image": "submittyrpi/csci1200:default"
+        "container_image": "submitty/autograding:latest"
     },
 
     "testcases" : [
@@ -11,17 +11,7 @@
         {
             "type" : "Compilation",
             "title" : "C++ - Compilation (for Dr Memory)",
-
-            // ORIGINAL
-            //"command" : "clang++ -g -Wall -o a.out *.cpp",
-
-            // TEMPORARY WORKAROUND
-            "command" : "clang++ -g -gdwarf-4 -Wall -o a.out *.cpp",
-            // NOTE: Compiling with the -gdwarf-4 option is required with g++ 11+
-            // so that DrMemory can print source code line numbers with.
-            // See also:
-            // https://github.com/DynamoRIO/drmemory/issues/2485
-
+            "command" : "clang++ -g -Wall -o a.out *.cpp",
             "executable_name" : "a.out",
             "points" : 2
         },


### PR DESCRIPTION
Replace some of the docker images used by the examples.
(Also replace use of submitty_count with the tree-sitter version submitty_count_ts)