### PR TITLE
[Testing:Submission] Remove Dates from course config

### DIFF
--- a/course_config.yml
+++ b/course_config.yml
@@ -11,16 +11,6 @@ gradeables:
         marks:
           - gcm_note: Full Credit
             gcm_points: 0
-    g_ta_view_start_date: -4 days
-    eg_submission_open_date: -2 days
-    eg_submission_due_date: +38 days
-    g_grade_start_date: +41 days
-    g_grade_due_date: +43 days
-    g_grade_released_date: +43 days
-    eg_grade_inquiry_start_date: +44 days
-    eg_grade_inquiry_due_date: +50 days
-    eg_has_due_date: true
-    eg_has_release_date: true
     eg_max_random_submissions: 0
 
   - gradeable_config: 02_simple_cpp
@@ -33,16 +23,6 @@ gradeables:
         marks:
           - gcm_note: Full Credit
             gcm_points: 0
-    g_ta_view_start_date: -4 days
-    eg_submission_open_date: -2 days
-    eg_submission_due_date: +36 days
-    g_grade_start_date: +39 days
-    g_grade_due_date: +41 days
-    g_grade_released_date: +41 days
-    eg_grade_inquiry_start_date: +42 days
-    eg_grade_inquiry_due_date: +48 days
-    eg_has_due_date: true
-    eg_has_release_date: true
     eg_max_random_submissions: 0
 
   - gradeable_config: 03_multipart
@@ -55,16 +35,6 @@ gradeables:
         marks:
           - gcm_note: Full Credit
             gcm_points: 0
-    g_ta_view_start_date: -4 days
-    eg_submission_open_date: -2 days
-    eg_submission_due_date: +34 days
-    g_grade_start_date: +37 days
-    g_grade_due_date: +39 days
-    g_grade_released_date: +39 days
-    eg_grade_inquiry_start_date: +40 days
-    eg_grade_inquiry_due_date: +46 days
-    eg_has_due_date: true
-    eg_has_release_date: true
     eg_max_random_submissions: 0
 
   - gradeable_config: 04_python_static_analysis
@@ -77,16 +47,6 @@ gradeables:
         marks:
           - gcm_note: Full Credit
             gcm_points: 0
-    g_ta_view_start_date: -4 days
-    eg_submission_open_date: -2 days
-    eg_submission_due_date: +32 days
-    g_grade_start_date: +35 days
-    g_grade_due_date: +37 days
-    g_grade_released_date: +37 days
-    eg_grade_inquiry_start_date: +38 days
-    eg_grade_inquiry_due_date: +44 days
-    eg_has_due_date: true
-    eg_has_release_date: true
     eg_max_random_submissions: 0
 
   - gradeable_config: 05_cpp_static_analysis
@@ -99,16 +59,6 @@ gradeables:
         marks:
           - gcm_note: Full Credit
             gcm_points: 0
-    g_ta_view_start_date: -4 days
-    eg_submission_open_date: -2 days
-    eg_submission_due_date: +30 days
-    g_grade_start_date: +33 days
-    g_grade_due_date: +35 days
-    g_grade_released_date: +35 days
-    eg_grade_inquiry_start_date: +36 days
-    eg_grade_inquiry_due_date: +42 days
-    eg_has_due_date: true
-    eg_has_release_date: true
     eg_max_random_submissions: 0
 
   - gradeable_config: 06_loop_types
@@ -121,16 +71,6 @@ gradeables:
         marks:
           - gcm_note: Full Credit
             gcm_points: 0
-    g_ta_view_start_date: -4 days
-    eg_submission_open_date: -2 days
-    eg_submission_due_date: +28 days
-    g_grade_start_date: +31 days
-    g_grade_due_date: +33 days
-    g_grade_released_date: +33 days
-    eg_grade_inquiry_start_date: +34 days
-    eg_grade_inquiry_due_date: +40 days
-    eg_has_due_date: true
-    eg_has_release_date: true
     eg_max_random_submissions: 0
 
   - gradeable_config: 07_loop_depth
@@ -143,16 +83,6 @@ gradeables:
         marks:
           - gcm_note: Full Credit
             gcm_points: 0
-    g_ta_view_start_date: -4 days
-    eg_submission_open_date: -2 days
-    eg_submission_due_date: +26 days
-    g_grade_start_date: +29 days
-    g_grade_due_date: +31 days
-    g_grade_released_date: +31 days
-    eg_grade_inquiry_start_date: +32 days
-    eg_grade_inquiry_due_date: +38 days
-    eg_has_due_date: true
-    eg_has_release_date: true
     eg_max_random_submissions: 0
 
   - gradeable_config: 08_memory_debugging
@@ -165,16 +95,6 @@ gradeables:
         marks:
           - gcm_note: Full Credit
             gcm_points: 0
-    g_ta_view_start_date: -4 days
-    eg_submission_open_date: -2 days
-    eg_submission_due_date: +24 days
-    g_grade_start_date: +27 days
-    g_grade_due_date: +29 days
-    g_grade_released_date: +29 days
-    eg_grade_inquiry_start_date: +30 days
-    eg_grade_inquiry_due_date: +36 days
-    eg_has_due_date: true
-    eg_has_release_date: true
     eg_max_random_submissions: 0
 
   - gradeable_config: 09_java_testing
@@ -187,16 +107,6 @@ gradeables:
         marks:
           - gcm_note: Full Credit
             gcm_points: 0
-    g_ta_view_start_date: -4 days
-    eg_submission_open_date: -2 days
-    eg_submission_due_date: +22 days
-    g_grade_start_date: +25 days
-    g_grade_due_date: +27 days
-    g_grade_released_date: +27 days
-    eg_grade_inquiry_start_date: +28 days
-    eg_grade_inquiry_due_date: +34 days
-    eg_has_due_date: true
-    eg_has_release_date: true
     eg_max_random_submissions: 0
 
   - gradeable_config: 10_java_coverage
@@ -209,16 +119,6 @@ gradeables:
         marks:
           - gcm_note: Full Credit
             gcm_points: 0
-    g_ta_view_start_date: -4 days
-    eg_submission_open_date: -2 days
-    eg_submission_due_date: +20 days
-    g_grade_start_date: +23 days
-    g_grade_due_date: +25 days
-    g_grade_released_date: +25 days
-    eg_grade_inquiry_start_date: +26 days
-    eg_grade_inquiry_due_date: +32 days
-    eg_has_due_date: true
-    eg_has_release_date: true
     eg_max_random_submissions: 0
 
   - gradeable_config: 11_resources
@@ -231,16 +131,6 @@ gradeables:
         marks:
           - gcm_note: Full Credit
             gcm_points: 0
-    g_ta_view_start_date: -4 days
-    eg_submission_open_date: -2 days
-    eg_submission_due_date: +18 days
-    g_grade_start_date: +21 days
-    g_grade_due_date: +23 days
-    g_grade_released_date: +23 days
-    eg_grade_inquiry_start_date: +24 days
-    eg_grade_inquiry_due_date: +30 days
-    eg_has_due_date: true
-    eg_has_release_date: true
     eg_max_random_submissions: 0
 
   - gradeable_config: 12_system_calls
@@ -253,16 +143,6 @@ gradeables:
         marks:
           - gcm_note: Full Credit
             gcm_points: 0
-    g_ta_view_start_date: -4 days
-    eg_submission_open_date: -2 days
-    eg_submission_due_date: +16 days
-    g_grade_start_date: +19 days
-    g_grade_due_date: +21 days
-    g_grade_released_date: +21 days
-    eg_grade_inquiry_start_date: +22 days
-    eg_grade_inquiry_due_date: +28 days
-    eg_has_due_date: true
-    eg_has_release_date: true
     eg_max_random_submissions: 0
 
   - gradeable_config: 13_cmake_compilation
@@ -275,16 +155,6 @@ gradeables:
         marks:
           - gcm_note: Full Credit
             gcm_points: 0
-    g_ta_view_start_date: -4 days
-    eg_submission_open_date: -2 days
-    eg_submission_due_date: +14 days
-    g_grade_start_date: +17 days
-    g_grade_due_date: +19 days
-    g_grade_released_date: +19 days
-    eg_grade_inquiry_start_date: +20 days
-    eg_grade_inquiry_due_date: +26 days
-    eg_has_due_date: true
-    eg_has_release_date: true
     eg_max_random_submissions: 0
 
   - gradeable_config: 14_tkinter
@@ -297,16 +167,6 @@ gradeables:
         marks:
           - gcm_note: Full Credit
             gcm_points: 0
-    g_ta_view_start_date: -4 days
-    eg_submission_open_date: -2 days
-    eg_submission_due_date: +12 days
-    g_grade_start_date: +15 days
-    g_grade_due_date: +17 days
-    g_grade_released_date: +17 days
-    eg_grade_inquiry_start_date: +18 days
-    eg_grade_inquiry_due_date: +24 days
-    eg_has_due_date: true
-    eg_has_release_date: true
     eg_max_random_submissions: 0
 
   - gradeable_config: 15_GLFW
@@ -319,16 +179,6 @@ gradeables:
         marks:
           - gcm_note: Full Credit
             gcm_points: 0
-    g_ta_view_start_date: -4 days
-    eg_submission_open_date: -2 days
-    eg_submission_due_date: +10 days
-    g_grade_start_date: +13 days
-    g_grade_due_date: +15 days
-    g_grade_released_date: +15 days
-    eg_grade_inquiry_start_date: +16 days
-    eg_grade_inquiry_due_date: +22 days
-    eg_has_due_date: true
-    eg_has_release_date: true
     eg_max_random_submissions: 0
 
   - gradeable_config: 16_docker_network_python
@@ -341,16 +191,6 @@ gradeables:
         marks:
           - gcm_note: Full Credit
             gcm_points: 0
-    g_ta_view_start_date: -4 days
-    eg_submission_open_date: -2 days
-    eg_submission_due_date: +8 days
-    g_grade_start_date: +11 days
-    g_grade_due_date: +13 days
-    g_grade_released_date: +13 days
-    eg_grade_inquiry_start_date: +14 days
-    eg_grade_inquiry_due_date: +20 days
-    eg_has_due_date: true
-    eg_has_release_date: true
     eg_max_random_submissions: 0
 
   - gradeable_config: 17_dispatched_actions_and_standard_input
@@ -363,16 +203,6 @@ gradeables:
         marks:
           - gcm_note: Full Credit
             gcm_points: 0
-    g_ta_view_start_date: -4 days
-    eg_submission_open_date: -2 days
-    eg_submission_due_date: +6 days
-    g_grade_start_date: +9 days
-    g_grade_due_date: +11 days
-    g_grade_released_date: +11 days
-    eg_grade_inquiry_start_date: +12 days
-    eg_grade_inquiry_due_date: +18 days
-    eg_has_due_date: true
-    eg_has_release_date: true
     eg_max_random_submissions: 0
 
   - gradeable_config: 18_postgres_database
@@ -385,14 +215,4 @@ gradeables:
         marks:
           - gcm_note: Full Credit
             gcm_points: 0
-    g_ta_view_start_date: -4 days
-    eg_submission_open_date: -2 days
-    eg_submission_due_date: +4 days
-    g_grade_start_date: +7 days
-    g_grade_due_date: +9 days
-    g_grade_released_date: +9 days
-    eg_grade_inquiry_start_date: +10 days
-    eg_grade_inquiry_due_date: +16 days
-    eg_has_due_date: true
-    eg_has_release_date: true
     eg_max_random_submissions: 0


### PR DESCRIPTION
Removes the dates for course config
Related to https://github.com/Submitty/Submitty/pull/11701
This ensures that the course never expires. Verified with `recreate_sample_courses tutorial`