### PR TITLE
[Bugfix:Autograding] remove reference to custom router (missing?)

### DIFF
--- a/examples/16_docker_network_python/config/config.json
+++ b/examples/16_docker_network_python/config/config.json
@@ -233,11 +233,12 @@
                     // In this example, we want the server to start before the client, so we add a sleep command.
                     "commands" : ["python3 -u client.py"]
                     // By not specifying a outgoing_connections array, we allow ourselves to connect to all nodes on the network
-                },
+                }
+                /*,
                 {
                     "container_name" : "router",
                     "commands" : ["python3 -u custom_router.py"]
-                }
+                }*/
             ],
             "dispatcher_actions" : [
               {


### PR DESCRIPTION
16_docker_network_python gradeable was broken -- referenced a custom router that is missing 
(did this ever work without the missing file?  where is the missing file?)