### PR TITLE
[Refactor:Developer] Replace submitty_count

### DIFF
--- a/examples/04_python_static_analysis/config/config.json
+++ b/examples/04_python_static_analysis/config/config.json
@@ -7,9 +7,9 @@
       // The first is to execute the student code, the second is to count the number of calls to the
       // "print" function.
       "command" : [ "python3 *.py",
-		    	"submitty_count_ts python node = *.py",
-		    	"submitty_count_ts python node * *.py",
-		    	"submitty_count_ts python node + *.py" ],
+		    	"submitty_count_ts -l python node = *.py",
+		    	"submitty_count_ts -l python node \\\\* *.py",
+		    	"submitty_count_ts -l python node + *.py" ],
       "points" : 4,
       "validation" : [
         // First, ensure that the student received the correct answer.

--- a/examples/04_python_static_analysis/config/config.json
+++ b/examples/04_python_static_analysis/config/config.json
@@ -7,9 +7,12 @@
       // The first is to execute the student code, the second is to count the number of calls to the
       // "print" function.
       "command" : [ "python3 *.py",
-	            "submitty_count token -l python Equal *.py",
-		    "submitty_count token -l python Asterisk *.py",
-		    "submitty_count token -l python Plus *.py" ],
+				// "submitty_count token -l python Equal *.py",
+		    // "submitty_count token -l python Asterisk *.py",
+		    // "submitty_count token -l python Plus *.py" ],
+		    	"submitty_count_ts -l python node = *.py",
+		    	"submitty_count_ts -l python node * *.py",
+		    	"submitty_count_ts -l python node + *.py" ],
       "points" : 4,
       "validation" : [
         // First, ensure that the student received the correct answer.

--- a/examples/04_python_static_analysis/config/config.json
+++ b/examples/04_python_static_analysis/config/config.json
@@ -1,4 +1,8 @@
 {
+	"autograding_method": "docker",
+	"container_options": {
+  "container_image": "dagemcn/dockerimages:default-test"
+ 	},
   "testcases" : [
     {
       "title" : "Python - Static Analysis",
@@ -7,12 +11,9 @@
       // The first is to execute the student code, the second is to count the number of calls to the
       // "print" function.
       "command" : [ "python3 *.py",
-				// "submitty_count token -l python Equal *.py",
-		    // "submitty_count token -l python Asterisk *.py",
-		    // "submitty_count token -l python Plus *.py" ],
-		    	"submitty_count_ts -l python node = *.py",
-		    	"submitty_count_ts -l python node * *.py",
-		    	"submitty_count_ts -l python node + *.py" ],
+		    	"submitty_count_ts python node = *.py",
+		    	"submitty_count_ts python node * *.py",
+		    	"submitty_count_ts python node + *.py" ],
       "points" : 4,
       "validation" : [
         // First, ensure that the student received the correct answer.
@@ -33,7 +34,7 @@
           // against the provided term (here, "greater-than-or-equal" is used).
 	  "comparison" : "ge",
           // The integer against which to compare.
-	  "term" : 5,
+	  "term" : 2,
 
           // Message to the student.
 	  "failure_message" : "Re-read the problem instructions.",
@@ -47,7 +48,7 @@
 	  "actual_file" : "STDOUT_2.txt",
 	  "description" : "Number of multiplications",
 	  "comparison" : "ge",
-	  "term" : 7,
+	  "term" : 2,
 	  "failure_message" : "Re-read the problem instructions.",
 	  "show_message" : "on_failure",
 	  "show_actual" : "never"

--- a/examples/04_python_static_analysis/config/config.json
+++ b/examples/04_python_static_analysis/config/config.json
@@ -1,8 +1,4 @@
 {
-	"autograding_method": "docker",
-	"container_options": {
-  "container_image": "dagemcn/dockerimages:default-test"
- 	},
   "testcases" : [
     {
       "title" : "Python - Static Analysis",
@@ -34,7 +30,7 @@
           // against the provided term (here, "greater-than-or-equal" is used).
 	  "comparison" : "ge",
           // The integer against which to compare.
-	  "term" : 2,
+	  "term" : 5,
 
           // Message to the student.
 	  "failure_message" : "Re-read the problem instructions.",
@@ -48,7 +44,7 @@
 	  "actual_file" : "STDOUT_2.txt",
 	  "description" : "Number of multiplications",
 	  "comparison" : "ge",
-	  "term" : 2,
+	  "term" : 7,
 	  "failure_message" : "Re-read the problem instructions.",
 	  "show_message" : "on_failure",
 	  "show_actual" : "never"

--- a/examples/06_loop_types/config/config.json
+++ b/examples/06_loop_types/config/config.json
@@ -2,8 +2,6 @@
   "testcases" : [
     {
       "title" : "Python - Distinguish for and while Loops",
-      // "command" : [ "submitty_count -l python node for *.py",
-      //               "submitty_count -l python token While *.py" ],
       "command" : [ "submitty_count_ts -l python node for *.py",
                     "submitty_count_ts -l python node While *.py" ],
       "points" : 2,

--- a/examples/06_loop_types/config/config.json
+++ b/examples/06_loop_types/config/config.json
@@ -2,8 +2,10 @@
   "testcases" : [
     {
       "title" : "Python - Distinguish for and while Loops",
-      "command" : [ "submitty_count -l python node for *.py",
-                    "submitty_count -l python token While *.py" ],
+      // "command" : [ "submitty_count -l python node for *.py",
+      //               "submitty_count -l python token While *.py" ],
+      "command" : [ "submitty_count_ts -l python node for *.py",
+                    "submitty_count_ts -l python node While *.py" ],
       "points" : 2,
       "validation" : [
         {

--- a/examples/06_loop_types/config/config.json
+++ b/examples/06_loop_types/config/config.json
@@ -3,7 +3,7 @@
     {
       "title" : "Python - Distinguish for and while Loops",
       "command" : [ "submitty_count_ts -l python node for *.py",
-                    "submitty_count_ts -l python node While *.py" ],
+                    "submitty_count_ts -l python node while *.py" ],
       "points" : 2,
       "validation" : [
         {

--- a/examples/07_loop_depth/config/config.json
+++ b/examples/07_loop_depth/config/config.json
@@ -20,7 +20,7 @@
 //           "description" : "Loop Depth",
 
 //           "comparison" : "ge",
-//           "term" : 0,
+//           "term" : 3 ,
 
 //           // "failure_message" : "Must have less than four nested loops",
 //           // "show_message" : "always",

--- a/examples/07_loop_depth/config/config.json
+++ b/examples/07_loop_depth/config/config.json
@@ -6,7 +6,8 @@
       // Here, an instructor-provided static analysis script is used, rather
       // than one of the provided scripts like count_token and count_function.
       // This works in much the same way as those scripts.
-      "command" : [ "submitty_count -l python depth loop *.py" ],
+      // "command" : [ "submitty_count -l python depth loop *.py" ],
+      "command" : [ "submitty_count_ts -l python node while *.py" ],
       "points" : 10,
       "validation" : [
         {

--- a/examples/07_loop_depth/config/config.json
+++ b/examples/07_loop_depth/config/config.json
@@ -7,7 +7,10 @@
       // than one of the provided scripts like count_token and count_function.
       // This works in much the same way as those scripts.
       // "command" : [ "submitty_count -l python depth loop *.py" ],
-      "command" : [ "submitty_count_ts -l python node while *.py" ],
+      // In the process of deprecating submitty_count and replacing it with submitty_count_ts, the loop depth functionality
+      // was lost. This example should either be updated or removed.
+      // ""
+      "command" : [ "submitty_count_ts -l python call print *.py" ],
       "points" : 10,
       "validation" : [
         {
@@ -15,11 +18,11 @@
           "actual_file" : "STDOUT.txt",
           "description" : "Loop Depth",
 
-          "comparison" : "le",
-          "term" : 3,
+          "comparison" : "ge",
+          "term" : 0,
 
-          "failure_message" : "Must have less than four nested loops",
-          "show_message" : "always",
+          // "failure_message" : "Must have less than four nested loops",
+          // "show_message" : "always",
           "show_actual" : "always"
         }
       ]

--- a/examples/07_loop_depth/config/config.json
+++ b/examples/07_loop_depth/config/config.json
@@ -1,31 +1,32 @@
+// FIXME: In the process of deprecating submitty_count and replacing it with submitty_count_ts, the loop depth functionality
+// was lost. This example should either be updated or removed.
 {
   "testcases" : [
-    {
-      "title" : "Python - Determine Loop Depth",
+  ]
+//     {
+//       "title" : "Python - Determine Loop Depth",
 
       // Here, an instructor-provided static analysis script is used, rather
       // than one of the provided scripts like count_token and count_function.
       // This works in much the same way as those scripts.
       // "command" : [ "submitty_count -l python depth loop *.py" ],
-      // In the process of deprecating submitty_count and replacing it with submitty_count_ts, the loop depth functionality
-      // was lost. This example should either be updated or removed.
       // ""
-      "command" : [ "submitty_count_ts -l python call print *.py" ],
-      "points" : 10,
-      "validation" : [
-        {
-          "method" : "intComparison",
-          "actual_file" : "STDOUT.txt",
-          "description" : "Loop Depth",
+//       "command" : [ "submitty_count_ts -l python call print *.py" ],
+//       "points" : 10,
+//       "validation" : [
+//         {
+//           "method" : "intComparison",
+//           "actual_file" : "STDOUT.txt",
+//           "description" : "Loop Depth",
 
-          "comparison" : "ge",
-          "term" : 0,
+//           "comparison" : "ge",
+//           "term" : 0,
 
-          // "failure_message" : "Must have less than four nested loops",
-          // "show_message" : "always",
-          "show_actual" : "always"
-        }
-      ]
-    }
-  ]
+//           // "failure_message" : "Must have less than four nested loops",
+//           // "show_message" : "always",
+//           "show_actual" : "always"
+//         }
+//       ]
+//     }
+//   ]
 }


### PR DESCRIPTION
### What is the current behavior?
Fixes Submitty [Issue#11784](https://github.com/Submitty/Submitty/issues/11784) - This one of the companion PRs to Submitty [PR#12609](https://github.com/Submitty/Submitty/pull/12609). 
The tutorial courses 04 - Python Static Analysis, 06 - Loop Types, and 07 - Loop Depth all use `submitty_count` in their autograding configs. This command is being deprecated, so we should update it. 

### What is the new behavior?
`submitty_count` has been removed from `04 - Python Static Analysis` and `06 - Loop Types` and replaced with `submitty_count_ts` in preparation for deprecation. For `07 - Loop Depth`, there was no equivalent functionality present in `submitty_count_ts` so the testcase is entirely commented out.

### Other information?
<!-- Is this a breaking change? -->
This specific PR is not a breaking change. However, the other PRs accompanying this one are breaking PRs.
<!-- How did you test -->
Tested that all homework configs still build and their accompanying still submissions work as intended.
